### PR TITLE
fix: reuse detector model across pages instead of reloading per page

### DIFF
--- a/src/ocr.py
+++ b/src/ocr.py
@@ -154,6 +154,7 @@ def process(args):
         print("Output Directory is not found.")
         return
     
+    detector=get_detector(args)
     recognizer100=get_recognizer(args=args)
     recognizer30=get_recognizer(args=args,weights_path=args.rec_weights30)
     recognizer50=get_recognizer(args=args,weights_path=args.rec_weights50)
@@ -169,7 +170,7 @@ def process(args):
         resjsonarray=[]
         imgname=os.path.basename(inputpath)
         img_h,img_w=img.shape[:2]
-        detections,classeslist=inference_on_detector(args=args,inputname=imgname,npimage=img,outputpath=args.output,issaveimg=args.viz)
+        detections,classeslist=process_detector(detector,inputname=imgname,npimage=img,outputpath=args.output,issaveimg=args.viz)
         e1=time.time()
         resultobj=[dict(),dict()]
         resultobj[0][0]=list()


### PR DESCRIPTION
## 概要

`process()` 関数内で `inference_on_detector()` がページごとに呼ばれていますが、この関数は内部で `get_detector(args)` を毎回呼び出し、DEIMモデルをディスクから再読み込みしています。

既に `process_detector()` 関数が用意されており、recognizer（recognizer30/50/100）と同様に、detectorも起動時に1回だけ作成して使い回すのが正しい設計と思われます。

## 変更内容

- `process()` のループ前で `detector = get_detector(args)` を1回実行
- ループ内で `inference_on_detector(args, ...)` → `process_detector(detector, ...)` に置換

## 効果（M3 MacBook Air で計測）

| 設定 | 1ページあたり |
|------|-------------|
| 変更前（毎回モデル再読み込み） | ~2,300ms |
| **変更後（モデル再利用）** | **~800ms** |

`--sourcedir` で複数画像を処理する場合、ページ数に比例して効果が大きくなります。

## 関連Issue

#2