### PR TITLE
DEIMの検出結果を画像境界にクリップする修正

### DIFF
--- a/src/deim.py
+++ b/src/deim.py
@@ -102,6 +102,8 @@ class DEIM:
             self.image_height / self.input_width
         ], dtype=np.float32)
         boxes = (predictions[:, :4] * scales).astype(np.int32)
+        boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], 0, self.image_width)
+        boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], 0, self.image_height)
         detections = []
         for bbox, score, label,char_count in zip(boxes, scores, class_ids,char_counts):
             class_index=int(label)-1


### PR DESCRIPTION
## 概要

`DEIM.postprocess()` で座標スケーリング後のバウンディングボックスが画像境界外（負の座標や画像サイズ超過）になるケースがあり、後段の処理に影響を与える問題を修正しました。

## 問題

DEIMの検出結果のうち、一部のバウンディングボックスのY座標が負の値になることがあります。同一の行に対して正常なbboxと負のY座標を持つbboxの2つが検出された場合、`remove_dup`（`reorder.py`）がIoU/minArea比較で信頼度の高い方を残しますが、負のY座標を持つ検出の方が信頼度が高い場合があり、正常な方が除去されます。

結果として、残ったbboxで画像をcropする際に画像外の領域を含むことになり、PARSeqの文字認識が失敗（空文字列や文字の断片出力）します。

### 再現条件
- 縦書き日本語テキスト（Kindle Cloud Reader等のスクリーンショット）
- 画像サイズ: 約3000x1500〜6000x3200px
- きわ近くまでクロップした画像（例: 夏目漱石-三四郎）
<img width="3006" height="1558" alt="page_0002_viz" src="https://github.com/user-attachments/assets/5dd8aab1-150e-4bb9-8ca1-93c8df3b83f5" />

### 再現例（6263x3246の画像で検出された同一行の2つのbbox）
```
残った: X=1532 Y=-203 W=108 H=3386 conf=0.870  ← Yが負、confが高い
消えた: X=1531 Y=  25 W=109 H=3177 conf=0.435  ← Yが正常、confが低い
```

この場合、Y=-203でcropされた画像は上部に無効な領域を含み、PARSeqが認識に失敗します。

## 修正内容

`src/deim.py` の `postprocess()` で、座標スケーリング後に `np.clip` で画像境界内にクリップする2行を追加しました。

```python
boxes[:, [0, 2]] = np.clip(boxes[:, [0, 2]], 0, self.image_width)
boxes[:, [1, 3]] = np.clip(boxes[:, [1, 3]], 0, self.image_height)
```

## 効果

修正前: 35行検出 → XY-Cut後29行（6行がremove_dupで除去）→ うち複数行が認識失敗
修正後: 同じ35行検出 → XY-Cut後29行（同じ6行が除去）→ 全29行が正常に認識

クリップにより、`remove_dup`で残る側のbboxも有効な画像領域内に収まるため、どちらが残っても認識が正常に動作します。