### PR TITLE
ファイル名にドットが含まれる場合に出力ファイル名が欠損する問題の修正

### DIFF
--- a/ndlocr-lite-gui/main.py
+++ b/ndlocr-lite-gui/main.py
@@ -346,7 +346,7 @@ class ImageSelector:
         buff = BytesIO()
         im_crop.save(buff, "png")
         self.crop_image.src_base64=base64.b64encode(buff.getvalue()).decode("utf-8")
-        self.outputcroppedpath=os.path.join(os.getcwd(),PDFTMPPATH,os.path.basename(self.image_src).split(".")[0]+"_cropped_{}.jpg".format(self.cnt))
+        self.outputcroppedpath=os.path.join(os.getcwd(),PDFTMPPATH,os.path.splitext(os.path.basename(self.image_src))[0]+"_cropped_{}.jpg".format(self.cnt))
         #im_crop.save(self.outputcroppedpath)
         self.mini_ocr(im_crop)
         self.cnt+=1
@@ -415,7 +415,7 @@ class ImageSelector:
         
         if alllinecnt==0 or tatelinecnt/alllinecnt>0.5:
             alltextlist=alltextlist[::-1]
-        with open(os.path.join(self.outputdirpath,os.path.basename(inputname).split(".")[0]+".txt"),"w",encoding="utf-8") as wtf:
+        with open(os.path.join(self.outputdirpath,os.path.splitext(os.path.basename(inputname))[0]+".txt"),"w",encoding="utf-8") as wtf:
             wtf.write("\n".join(alltextlist))
         self.resulttext.value="\n".join(alltextlist)
         self.cropocr_btn.disabled=False
@@ -1087,7 +1087,7 @@ def main(page: ft.Page):
                     }
                     alljsonobjlist.append(alljsonobj)
                     if chkbx_xml.value:
-                        with open(os.path.join(outputpath,os.path.basename(inputpath).split(".")[0]+".xml"),"w",encoding="utf-8") as wf:
+                        with open(os.path.join(outputpath,os.path.splitext(os.path.basename(inputpath))[0]+".xml"),"w",encoding="utf-8") as wf:
                             wf.write(allxmlstr)
                     if chkbx_visualize.value:
                         output_vizpath=os.path.join(outputpath,"viz_"+os.path.basename(inputpath))
@@ -1096,13 +1096,13 @@ def main(page: ft.Page):
                         visualizepathlist.append(output_vizpath)
                         origin_detector.drawxml_detections(npimg=img,xmlstr=allxmlstr,categories=categories_org_name_index,outputimgpath=output_vizpath)
                     if chkbx_json.value:
-                        with open(os.path.join(outputpath,os.path.basename(inputpath).split(".")[0]+".json"),"w",encoding="utf-8") as wf:
+                        with open(os.path.join(outputpath,os.path.splitext(os.path.basename(inputpath))[0]+".json"),"w",encoding="utf-8") as wf:
                             wf.write(json.dumps(alljsonobj,ensure_ascii=False,indent=2))
                     if chkbx_txt.value:
-                        with open(os.path.join(outputpath,os.path.basename(inputpath).split(".")[0]+".txt"),"w",encoding="utf-8") as wtf:
+                        with open(os.path.join(outputpath,os.path.splitext(os.path.basename(inputpath))[0]+".txt"),"w",encoding="utf-8") as wtf:
                             wtf.write("\n".join(alltextlist))
                     if chkbx_pdf.value:
-                        create_pdf_func(os.path.join(outputpath,os.path.basename(inputpath).split(".")[0]+".pdf"),img,resjsonarray,chkbx_pdf_viztxt.value)
+                        create_pdf_func(os.path.join(outputpath,os.path.splitext(os.path.basename(inputpath))[0]+".pdf"),img,resjsonarray,chkbx_pdf_viztxt.value)
                         
                     progressbar.value+=1/allsum
                     preview_prev_btn.disabled=False
@@ -1122,7 +1122,7 @@ def main(page: ft.Page):
                     progressmessage.value="{} images completed / Total time {:.2f} sec".format(allsum,time.time()-allstart)
                 progressmessage.update()
                 if chkbx_tei.value:
-                    with open(os.path.join(outputpath,os.path.basename(inputpathlist[0]).split(".")[0]+"_tei.xml"),"wb") as wf:
+                    with open(os.path.join(outputpath,os.path.splitext(os.path.basename(inputpathlist[0]))[0]+"_tei.xml"),"wb") as wf:
                         allxmlstrtei=convert_tei(alljsonobjlist)
                         wf.write(allxmlstrtei)
             except Exception as e:

--- a/src/reading_order/order/parse_xml.py
+++ b/src/reading_order/order/parse_xml.py
@@ -80,7 +80,7 @@ def parse_root(root, xml_path=None):
             ) else False if "false" == kyokaku.lower() else None
         dat["pages"].append({
             "index": i,
-            "pid": Path(xml_path).name.split(".")[0] if xml_path else "unknown",
+            "pid": Path(xml_path).stem if xml_path else "unknown",
             "width": int(page.get("WIDTH", -1)),
             "height": int(page.get("HEIGHT", -1)),
             "image": page.get("IMAGENAME"),


### PR DESCRIPTION
## 概要
- `abc.def.pdf` のようなドット入りファイル名を処理すると、出力が `abc.xml` / `abc.txt` となり `.def` が欠落する問題を修正
- `.split(".")[0]` を `os.path.splitext()[0]` / `Path.stem` に置き換え、最後の拡張子のみを除去するように変更

Closes ndl-lab/ndlocr-lite#36

## 試験内容
### 1
`digidepo_2531162.0024.jpg` 等のドット入りファイル名でOCR実行し、出力ファイル名が `digidepo_2531162.0024.xml` / `digidepo_2531162.0024.txt` となること



1. cp resource/digidepo_2531162_0024.jpg resource/digidepo_2531162.0024.jpg
2. resource/digidepo_2531162.0024.jpg をGUIに入力
3. 以下のファイルが出力されていることを確認
`digidepo_2531162.0024_tei.xml`, `digidepo_2531162.0024.json`, `digidepo_2531162.0024.txt`, `digidepo_2531162.0024.xml`, `viz_digidepo_2531162.0024.jpg`


### 2
`digidepo_2531162_0024.jpg` 等の通常ファイル名で従来通り動作すること

1. resource/digidepo_2531162_0024.jpg をGUIに入力
2. 以下のファイルが出力されていることを確認
`digidepo_2531162_0024_tei.xml`, `digidepo_2531162_0024.json`, `digidepo_2531162_0024.txt`, `digidepo_2531162_0024.xml`, `viz_digidepo_2531162_0024.jpg`
